### PR TITLE
Updated urls as old repository no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img align="right" src="https://raw.github.com/cliffano/pyaem/master/avatar.jpg" alt="Avatar"/>
 
-[![Build Status](https://secure.travis-ci.org/cliffano/pyaem.png?branch=master)](http://travis-ci.org/cliffano/pyaem)
+[![Build Status](https://secure.travis-ci.org/Sensis/pyaem.png?branch=master)](http://travis-ci.org/Sensis/pyaem)
 [![Coverage Status](https://coveralls.io/repos/cliffano/pyaem/badge.png?branch=master)](https://coveralls.io/r/cliffano/pyaem?branch=master)
 [![Published Version](https://badge.fury.io/py/pyaem.svg)](http://badge.fury.io/py/coveralls)
 <br/>

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ class PyTest(TestCommand):
 setup(
     name='pyaem',
     version='0.9.1',
-    url='http://github.com/cliffano/pyaem/',
+    url='https://github.com/Sensis/pyaem/',
     license='MIT License',
     author='Cliffano Subagio',
     tests_require=['mock', 'pytest'],


### PR DESCRIPTION
Updated `setup.py` to refer to this repository. The missing repository causes errors when using easy_install

Workaround for errors on easy_install

      install_requires=[
            'pyaem==0.9.1',
            ],
      dependency_links = [
            'https://github.com/Sensis/pyaem/zipball/0.9.1#egg=pyaem-0.9.1'
      ],

